### PR TITLE
Ensure items disable when hitting max.

### DIFF
--- a/app/BUILD.bazel
+++ b/app/BUILD.bazel
@@ -469,6 +469,7 @@ BINDING_ADAPTERS_WITH_RESOURCE_IMPORTS = [
 
 # keep sorted
 BINDING_ADAPTERS = [
+    "src/main/java/org/oppia/android/app/databinding/AppCompatCheckBoxBindingAdapters.java",
     "src/main/java/org/oppia/android/app/databinding/ConstraintLayoutAdapters.java",
     "src/main/java/org/oppia/android/app/databinding/EditTextBindingAdapters.java",
     "src/main/java/org/oppia/android/app/databinding/GuidelineBindingAdapters.java",

--- a/app/src/main/java/org/oppia/android/app/databinding/AppCompatCheckBoxBindingAdapters.java
+++ b/app/src/main/java/org/oppia/android/app/databinding/AppCompatCheckBoxBindingAdapters.java
@@ -1,0 +1,18 @@
+package org.oppia.android.app.databinding;
+
+import android.content.res.ColorStateList;
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.appcompat.widget.AppCompatCheckBox;
+import androidx.databinding.BindingAdapter;
+
+/**
+ * Custom data-binding adapters for {@link AppCompatCheckBox}s.
+ */
+public final class AppCompatCheckBoxBindingAdapters {
+  /** Sets the button tint for the specified checkbox, via data-binding. */
+  @BindingAdapter("app:buttonTint")
+  public static void setButtonTint(@NonNull AppCompatCheckBox checkBox, @ColorInt int colorRgb) {
+    checkBox.setSupportButtonTintList(ColorStateList.valueOf(colorRgb));
+  }
+}

--- a/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionInteractionViewModel.kt
+++ b/app/src/main/java/org/oppia/android/app/player/state/itemviewmodel/SelectionInteractionViewModel.kt
@@ -135,11 +135,12 @@ class SelectionInteractionViewModel private constructor(
       isCurrentlySelected -> {
         selectedItems -= itemIndex
         updateIsAnswerAvailable()
-        updateSelectionText(isCurrentlySelected)
+        updateSelectionText()
+        updateItemSelectability()
         false
       }
       !areCheckboxesBound() -> {
-        // Disable all items to simulate a radio button group.
+        // De-select all other items to simulate a radio button group.
         choiceItems.forEach { item -> item.isAnswerSelected.set(false) }
         selectedItems.clear()
         selectedItems += itemIndex
@@ -147,11 +148,10 @@ class SelectionInteractionViewModel private constructor(
         true
       }
       selectedItems.size < maxAllowableSelectionCount -> {
-        // TODO(#3624): Add warning to user when they exceed the number of allowable selections or are under the minimum
-        //  number required.
         selectedItems += itemIndex
         updateIsAnswerAvailable()
-        updateSelectionText(isCurrentlySelected)
+        updateSelectionText()
+        updateItemSelectability()
         true
       }
       else -> {
@@ -161,7 +161,7 @@ class SelectionInteractionViewModel private constructor(
     }
   }
 
-  private fun updateSelectionText(isCurrentlySelected: Boolean) {
+  private fun updateSelectionText() {
     if (selectedItems.size < maxAllowableSelectionCount) {
       selectedItemText.set(
         resourceHandler.getStringInLocale(
@@ -183,14 +183,14 @@ class SelectionInteractionViewModel private constructor(
           maxAllowableSelectionCount.toString()
         )
       )
-      for (items in selectedItems) {
-        enabledItemsList[items].set(true)
-      }
-    } else {
-      enabledItemsList.forEach {
-        it.set(true)
-      }
     }
+  }
+
+  private fun updateItemSelectability() {
+    if (selectedItems.size == maxAllowableSelectionCount) {
+      // All non-selected items should be disabled when the limit is reached.
+      enabledItemsList.filterIndexed { idx, _ -> idx !in selectedItems }.forEach { it.set(false) }
+    } else enabledItemsList.forEach { it.set(true) } // Otherwise, all items are available.
   }
 
   private fun areCheckboxesBound(): Boolean {

--- a/app/src/main/res/layout/item_selection_interaction_items.xml
+++ b/app/src/main/res/layout/item_selection_interaction_items.xml
@@ -32,7 +32,7 @@
       android:enabled="@{viewModel.enabledItem}"
       android:focusable="false"
       android:labelFor="@id/item_selection_contents_text_view"
-      app:buttonTint="@color/component_color_shared_item_selection_interaction_color" />
+      app:buttonTint="@{viewModel.enabledItem ? @color/component_color_shared_item_selection_interaction_enabled_color : @color/component_color_shared_item_selection_interaction_disabled_color}" />
 
     <TextView
       android:id="@+id/item_selection_contents_text_view"
@@ -44,7 +44,7 @@
       android:layout_toEndOf="@+id/item_selection_checkbox"
       android:fontFamily="sans-serif"
       android:text="@{htmlContent}"
-      android:textColor="@color/component_color_shared_item_selection_interaction_text_color"
+      android:textColor="@{viewModel.enabledItem ? @color/component_color_shared_item_selection_interaction_text_color : @color/component_color_shared_item_selection_interaction_disabled_color}"
       android:textSize="16sp" />
   </RelativeLayout>
 </layout>

--- a/app/src/main/res/values/component_colors.xml
+++ b/app/src/main/res/values/component_colors.xml
@@ -39,7 +39,8 @@
   <color name="component_color_shared_multiple_choice_interaction_selected_color">@color/color_palette_multiple_choice_selected_color</color>
   <color name="component_color_shared_multiple_choice_interaction_selected_text_color">@color/color_palette_multiple_choice_selected_text_color</color>
   <color name="component_color_shared_selection_interaction_item_text_color">@color/color_palette_primary_text_color</color>
-  <color name="component_color_shared_item_selection_interaction_color">@color/color_palette_item_selection_color</color>
+  <color name="component_color_shared_item_selection_interaction_enabled_color">@color/color_palette_item_selection_color</color>
+  <color name="component_color_shared_item_selection_interaction_disabled_color">@color/color_palette_disabled_button_background_color</color>
   <color name="component_color_shared_item_selection_interaction_text_color">@color/color_palette_item_selection_text_color</color>
   <color name="component_color_shared_back_arrow_button_color">@color/color_palette_back_arrow_button_color</color>
   <color name="component_color_shared_forward_arrow_button_color">@color/color_palette_forward_arrow_button_color</color>


### PR DESCRIPTION
This PR updates #4777 to ensure that the checkboxes are properly disabled when the max number of items is selected, and that they're visually updated to look disabled.

What it does not do that you'll need to do @Akshatkamboj14:
- [ ] Check with the design team on which color should be used for the disabled version (the current color seems to have too poor of a contrast).
- [x] Update tests to verify that the behaviors are working as expected.
- [x] Add tests for the new AppCompatCheckBoxBindingAdapters in a similar way to other adapters tests.
- [x] Update 4777 to mark #3624 as fixed.

Note that I already checked the accessibility flow and it seems pretty solid.